### PR TITLE
Fix branch name on coveralls.io

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,4 +48,4 @@ jobs:
         php vendor/bin/php-coveralls -v
       env:
         COVERALLS_RUN_LOCALLY: 1
-        COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
       if: matrix.php-versions == '7.2'
       run: |
         export CI_BRANCH=$GITHUB_REF
+        echo ${COVERALLS_REPO_TOKEN}
         php vendor/bin/php-coveralls -v
       env:
         COVERALLS_RUN_LOCALLY: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,4 +47,4 @@ jobs:
         coveralls build/logs/clover.xml
       env:
         COVERALLS_RUN_LOCALLY: 1
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       if: matrix.php-versions == '7.2'
       run: |
         export CI_BRANCH=$GITHUB_REF
-        export COVERALLS_SERVICE_NAME=github
+        export CI_NAME=github
         php vendor/bin/php-coveralls -v
       env:
         COVERALLS_RUN_LOCALLY: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,9 @@ jobs:
       run: vendor/bin/phpunit
     - name: Send to coveralls
       if: matrix.php-versions == '7.2'
-      run: php vendor/bin/php-coveralls -v
+      run: |
+        export CI_BRANCH=$GITHUB_REF
+        php vendor/bin/php-coveralls -v
       env:
         COVERALLS_RUN_LOCALLY: 1
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,8 @@ jobs:
     - name: Send to coveralls
       if: matrix.php-versions == '7.2'
       run: |
-        export CI_BRANCH=$GITHUB_REF
-        export CI_NAME=github
-        export CI_JOB_ID=$GITHUB_ACTIONS
-        php vendor/bin/php-coveralls -v
+        composer global require cedx/coveralls
+        coveralls build/logs/clover.xml
       env:
         COVERALLS_RUN_LOCALLY: 1
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       if: matrix.php-versions == '7.2'
       run: |
         export CI_BRANCH=$GITHUB_REF
-        echo ${COVERALLS_REPO_TOKEN}
+        export COVERALLS_SERVICE_NAME=github
         php vendor/bin/php-coveralls -v
       env:
         COVERALLS_RUN_LOCALLY: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
       if: matrix.php-versions == '7.2'
       run: |
         composer global require cedx/coveralls
+        export PATH="$PATH:~/.composer/vendor/bin/"
         coveralls build/logs/clover.xml
       env:
         COVERALLS_RUN_LOCALLY: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
       run: |
         export CI_BRANCH=$GITHUB_REF
         export CI_NAME=github
+        export CI_JOB_ID=$GITHUB_ACTIONS
         php vendor/bin/php-coveralls -v
       env:
         COVERALLS_RUN_LOCALLY: 1


### PR DESCRIPTION
Fixes representaion of branch name on coveralls.io

## Proposed Changes

  - Use secrets.GITHUB_TOKEN because GitHub automatically creates a GITHUB_TOKEN secret to use in your workflow.
  - Use `cedx/coveralls` for sending to coveralls.io (see [code](https://github.com/cedx/coveralls.php/blob/master/lib/Services/GitHub.php))
 
