### PR TITLE
Using the assertSame to assert eqauls are strict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-    "php": ">=7.1",
+    "php": ">=7.2",
     "ext-mbstring": "*",
     "lib-openssl": "*"
     },

--- a/tests/EE/EstcardTest.php
+++ b/tests/EE/EstcardTest.php
@@ -138,10 +138,10 @@ class EstcardTest extends TestCase
         $response = $this->bank->handleResponse($responseData);
 
         $this->assertInstanceOf('RKD\Banklink\Response\PaymentResponse', $response);
-        $this->assertEquals(PaymentResponse::STATUS_SUCCESS, $response->getStatus());
+        $this->assertSame(PaymentResponse::STATUS_SUCCESS, $response->getStatus());
 
         // We should get same message
-        $this->assertEquals('Test makse', $response->getMessage());
+        $this->assertSame('Test makse', $response->getMessage());
 
         // This is valid response
         $this->assertTrue($response->wasSuccessful());
@@ -181,6 +181,6 @@ class EstcardTest extends TestCase
         $request = $this->bank->getPaymentRequest($this->orderId, $this->amount, $this->message, $this->language, $this->currency, [], $this->timezone);
 
         // Custom url
-        $this->assertEquals('https://google.com', $request->getRequestUrl());
+        $this->assertSame('https://google.com', $request->getRequestUrl());
     }
 }

--- a/tests/EE/SEBTest.php
+++ b/tests/EE/SEBTest.php
@@ -209,7 +209,7 @@ class SEBTest extends TestCase
         $response = $this->bank->handleResponse($responseData);
 
         $this->assertInstanceOf('RKD\Banklink\Response\PaymentResponse', $response);
-        $this->assertEquals(PaymentResponse::STATUS_SUCCESS, $response->getStatus());
+        $this->assertSame(PaymentResponse::STATUS_SUCCESS, $response->getStatus());
 
         $this->assertEquals($this->sellerName, $response->getReceiver()->name);
         $this->assertEquals($this->sellerAccount, $response->getReceiver()->account);
@@ -244,7 +244,7 @@ class SEBTest extends TestCase
         $response = $this->bank->handleResponse($responseData);
 
         $this->assertInstanceOf('RKD\Banklink\Response\PaymentResponse', $response);
-        $this->assertEquals(PaymentResponse::STATUS_ERROR, $response->getStatus());
+        $this->assertSame(PaymentResponse::STATUS_ERROR, $response->getStatus());
 
         // This is not valid response, so validation should fail
         $this->assertFalse($response->wasSuccessful());
@@ -336,7 +336,7 @@ class SEBTest extends TestCase
         $request = $this->bank->getPaymentRequest($this->orderId, $this->amount, $this->message, $this->language, $this->currency, [], $this->timezone);
 
         // Custom url
-        $this->assertEquals('https://google.com', $request->getRequestUrl());
+        $this->assertSame('https://google.com', $request->getRequestUrl());
     }
 
     /**
@@ -372,8 +372,8 @@ class SEBTest extends TestCase
         ]);
 
         // Custom url set
-        $this->assertEquals('https://custom.com/auth', $this->bank->getRequestUrlFor('auth'));
-        $this->assertEquals('https://custom.com/pay', $this->bank->getRequestUrlFor('payment'));
+        $this->assertSame('https://custom.com/auth', $this->bank->getRequestUrlFor('auth'));
+        $this->assertSame('https://custom.com/pay', $this->bank->getRequestUrlFor('payment'));
     }
 
     /**
@@ -385,8 +385,8 @@ class SEBTest extends TestCase
         $this->bank->setRequestUrl('https://custom.com/endpoint');
 
         // Custom url set
-        $this->assertEquals('https://custom.com/endpoint', $this->bank->getRequestUrlFor('auth'));
-        $this->assertEquals('https://custom.com/endpoint', $this->bank->getRequestUrlFor('payment'));
+        $this->assertSame('https://custom.com/endpoint', $this->bank->getRequestUrlFor('auth'));
+        $this->assertSame('https://custom.com/endpoint', $this->bank->getRequestUrlFor('payment'));
     }
 
     /**
@@ -399,7 +399,7 @@ class SEBTest extends TestCase
         $this->bank = new $this->bankClass($this->protocol);
         $this->bank->setRequestUrl(null);
 
-        $this->assertEquals('https://custom.com/endpoint', $this->bank->getRequestUrlFor('payment'));
+        $this->assertSame('https://custom.com/endpoint', $this->bank->getRequestUrlFor('payment'));
     }
 
     /**
@@ -412,6 +412,6 @@ class SEBTest extends TestCase
         $this->bank = new $this->bankClass($this->protocol);
         $this->bank->setRequestUrl([]);
 
-        $this->assertEquals('https://custom.com/endpoint', $this->bank->getRequestUrlFor('payment'));
+        $this->assertSame('https://custom.com/endpoint', $this->bank->getRequestUrlFor('payment'));
     }
 }

--- a/tests/LT/LuminorTest.php
+++ b/tests/LT/LuminorTest.php
@@ -182,7 +182,7 @@ class LuminorTest extends TestCase
         $response = $this->bank->handleResponse($responseData);
 
         $this->assertInstanceOf('RKD\Banklink\Response\PaymentResponse', $response);
-        $this->assertEquals(PaymentResponse::STATUS_SUCCESS, $response->getStatus());
+        $this->assertSame(PaymentResponse::STATUS_SUCCESS, $response->getStatus());
 
         $this->assertEquals($this->sellerName, $response->getReceiver()->name);
         $this->assertEquals($this->sellerAccount, $response->getReceiver()->account);
@@ -217,7 +217,7 @@ class LuminorTest extends TestCase
         $response = $this->bank->handleResponse($responseData);
 
         $this->assertInstanceOf('RKD\Banklink\Response\PaymentResponse', $response);
-        $this->assertEquals(PaymentResponse::STATUS_ERROR, $response->getStatus());
+        $this->assertSame(PaymentResponse::STATUS_ERROR, $response->getStatus());
 
         // This is not valid response, so validation should fail
         $this->assertFalse($response->wasSuccessful());
@@ -240,7 +240,7 @@ class LuminorTest extends TestCase
         $request = $this->bank->getPaymentRequest($this->orderId, $this->amount, $this->message, $this->language, $this->currency, [], $this->timezone);
 
         // Custom url
-        $this->assertEquals('https://google.com', $request->getRequestUrl());
+        $this->assertSame('https://google.com', $request->getRequestUrl());
     }
 
     /**
@@ -276,8 +276,8 @@ class LuminorTest extends TestCase
         ]);
 
         // Custom url set
-        $this->assertEquals('https://custom.com/auth', $this->bank->getRequestUrlFor('auth'));
-        $this->assertEquals('https://custom.com/pay', $this->bank->getRequestUrlFor('payment'));
+        $this->assertSame('https://custom.com/auth', $this->bank->getRequestUrlFor('auth'));
+        $this->assertSame('https://custom.com/pay', $this->bank->getRequestUrlFor('payment'));
     }
 
     /**
@@ -289,8 +289,8 @@ class LuminorTest extends TestCase
         $this->bank->setRequestUrl('https://custom.com/endpoint');
 
         // Custom url set
-        $this->assertEquals('https://custom.com/endpoint', $this->bank->getRequestUrlFor('auth'));
-        $this->assertEquals('https://custom.com/endpoint', $this->bank->getRequestUrlFor('payment'));
+        $this->assertSame('https://custom.com/endpoint', $this->bank->getRequestUrlFor('auth'));
+        $this->assertSame('https://custom.com/endpoint', $this->bank->getRequestUrlFor('payment'));
     }
 
     /**
@@ -303,7 +303,7 @@ class LuminorTest extends TestCase
         $this->bank = new $this->bankClass($this->protocol);
         $this->bank->setRequestUrl(null);
 
-        $this->assertEquals('https://custom.com/endpoint', $this->bank->getRequestUrlFor('payment'));
+        $this->assertSame('https://custom.com/endpoint', $this->bank->getRequestUrlFor('payment'));
     }
 
     /**
@@ -316,6 +316,6 @@ class LuminorTest extends TestCase
         $this->bank = new $this->bankClass($this->protocol);
         $this->bank->setRequestUrl([]);
 
-        $this->assertEquals('https://custom.com/endpoint', $this->bank->getRequestUrlFor('payment'));
+        $this->assertSame('https://custom.com/endpoint', $this->bank->getRequestUrlFor('payment'));
     }
 }

--- a/tests/LT/SEBTest.php
+++ b/tests/LT/SEBTest.php
@@ -116,7 +116,7 @@ class SEBTest extends \RKD\Banklink\Test\EE\SEBTest
         $response = $this->bank->handleResponse($responseData);
 
         $this->assertInstanceOf('RKD\Banklink\Response\PaymentResponse', $response);
-        $this->assertEquals(PaymentResponse::STATUS_SUCCESS, $response->getStatus());
+        $this->assertSame(PaymentResponse::STATUS_SUCCESS, $response->getStatus());
 
         $this->assertEquals($this->sellerName, $response->getReceiver()->name);
         $this->assertEquals($this->sellerAccount, $response->getReceiver()->account);
@@ -151,7 +151,7 @@ class SEBTest extends \RKD\Banklink\Test\EE\SEBTest
         $response = $this->bank->handleResponse($responseData);
 
         $this->assertInstanceOf('RKD\Banklink\Response\PaymentResponse', $response);
-        $this->assertEquals(PaymentResponse::STATUS_ERROR, $response->getStatus());
+        $this->assertSame(PaymentResponse::STATUS_ERROR, $response->getStatus());
 
         // This is not valid response, so validation should fail
         $this->assertFalse($response->wasSuccessful());
@@ -186,7 +186,7 @@ class SEBTest extends \RKD\Banklink\Test\EE\SEBTest
         $response = $this->bank->handleResponse($responseData);
 
         $this->assertInstanceOf('RKD\Banklink\Response\PaymentResponse', $response);
-        $this->assertEquals(PaymentResponse::STATUS_ERROR, $response->getStatus());
+        $this->assertSame(PaymentResponse::STATUS_ERROR, $response->getStatus());
 
         // This is not valid response, so validation should fail
         $this->assertFalse($response->wasSuccessful());

--- a/tests/LT/SiauliuTest.php
+++ b/tests/LT/SiauliuTest.php
@@ -49,7 +49,7 @@ class SiauliuTest extends SEBTest
         $response = $this->bank->handleResponse($responseData);
 
         $this->assertInstanceOf('RKD\Banklink\Response\PaymentResponse', $response);
-        $this->assertEquals(PaymentResponse::STATUS_ERROR, $response->getStatus());
+        $this->assertSame(PaymentResponse::STATUS_ERROR, $response->getStatus());
 
         // This is not valid response, so validation should fail
         $this->assertFalse($response->wasSuccessful());

--- a/tests/Protocol/ECommerceTest.php
+++ b/tests/Protocol/ECommerceTest.php
@@ -154,6 +154,6 @@ class ECommerceTest extends TestCase
     public function testSetAlgorithm()
     {
         $this->protocol->setAlgorithm(OPENSSL_ALGO_SHA256);
-        $this->assertEquals(OPENSSL_ALGO_SHA256, $this->protocol->getAlgorithm());
+        $this->assertSame(OPENSSL_ALGO_SHA256, $this->protocol->getAlgorithm());
     }
 }

--- a/tests/Protocol/Helper/ProtocolHelperTest.php
+++ b/tests/Protocol/Helper/ProtocolHelperTest.php
@@ -19,14 +19,14 @@ class ProtocolHelperTest extends TestCase
     public function testcalculateReference()
     {
         $orderId = 12131295;
-        $expectedReference = 121312952;
+        $expectedReference = '121312952';
 
-        $this->assertEquals($expectedReference, ProtocolHelper::calculateReference($orderId));
+        $this->assertSame($expectedReference, ProtocolHelper::calculateReference($orderId));
 
         $orderId = 12131495;
-        $expectedReference = 121314950;
+        $expectedReference = '121314950';
 
-        $this->assertEquals($expectedReference, ProtocolHelper::calculateReference($orderId));
+        $this->assertSame($expectedReference, ProtocolHelper::calculateReference($orderId));
     }
 
     /**
@@ -44,10 +44,10 @@ class ProtocolHelperTest extends TestCase
      */
     public function testLangToISO6391()
     {
-        $this->assertEquals('et', ProtocolHelper::langToISO6391('est'));
-        $this->assertEquals('ru', ProtocolHelper::langToISO6391('rus'));
-        $this->assertEquals('en', ProtocolHelper::langToISO6391('eng'));
-        $this->assertEquals('fi', ProtocolHelper::langToISO6391('fin'));
+        $this->assertSame('et', ProtocolHelper::langToISO6391('est'));
+        $this->assertSame('ru', ProtocolHelper::langToISO6391('rus'));
+        $this->assertSame('en', ProtocolHelper::langToISO6391('eng'));
+        $this->assertSame('fi', ProtocolHelper::langToISO6391('fin'));
     }
 
     /**
@@ -58,6 +58,6 @@ class ProtocolHelperTest extends TestCase
         $ecuno = ProtocolHelper::generateEcuno();
 
         $this->assertStringStartsWith(date('Ym'), $ecuno);
-        $this->assertEquals(12, strlen($ecuno));
+        $this->assertSame(12, strlen($ecuno));
     }
 }

--- a/tests/Protocol/IPizza2015Test.php
+++ b/tests/Protocol/IPizza2015Test.php
@@ -102,7 +102,7 @@ class IPizza2015Test extends IPizzaTest
         $response = $this->protocol->handleResponse($responseData);
 
         $this->assertInstanceOf('RKD\Banklink\Response\PaymentResponse', $response);
-        $this->assertEquals(PaymentResponse::STATUS_SUCCESS, $response->getStatus());
+        $this->assertSame(PaymentResponse::STATUS_SUCCESS, $response->getStatus());
 
         // This is valid response
         $this->assertTrue($response->wasSuccessful());
@@ -114,7 +114,7 @@ class IPizza2015Test extends IPizzaTest
         $this->assertEquals($this->orderId, $response->getOrderId());
 
         // We should get same prefered language
-        $this->assertEquals('EST', $response->getLanguage());
+        $this->assertSame('EST', $response->getLanguage());
 
         // We should get same message
         $this->assertEquals($this->message, $response->getMessage());
@@ -132,7 +132,7 @@ class IPizza2015Test extends IPizzaTest
         $this->assertEquals($this->currency, $response->getCurrency());
         $this->assertEquals($expextedSender, $response->getSender());
         $this->assertEquals($expextedReceiver, $response->getReceiver());
-        $this->assertEquals(100, $response->getTransactionId());
+        $this->assertSame('100', $response->getTransactionId());
         $this->assertEquals($this->datetime, $response->getTransactionDate());
     }
 
@@ -156,7 +156,7 @@ class IPizza2015Test extends IPizzaTest
         $response = $this->protocol->handleResponse($responseData);
 
         $this->assertInstanceOf('RKD\Banklink\Response\PaymentResponse', $response);
-        $this->assertEquals(PaymentResponse::STATUS_ERROR, $response->getStatus());
+        $this->assertSame(PaymentResponse::STATUS_ERROR, $response->getStatus());
 
         // This is not valid response, so validation should fail
         $this->assertFalse($response->wasSuccessful());

--- a/tests/Protocol/IPizzaTest.php
+++ b/tests/Protocol/IPizzaTest.php
@@ -167,7 +167,7 @@ class IPizzaTest extends TestCase
         $response = $this->protocol->handleResponse($responseData);
 
         $this->assertInstanceOf('RKD\Banklink\Response\PaymentResponse', $response);
-        $this->assertEquals(PaymentResponse::STATUS_SUCCESS, $response->getStatus());
+        $this->assertSame(PaymentResponse::STATUS_SUCCESS, $response->getStatus());
 
         // This is valid response
         $this->assertTrue($response->wasSuccessful());
@@ -179,7 +179,7 @@ class IPizzaTest extends TestCase
         $this->assertEquals($this->orderId, $response->getOrderId());
 
         // We should get same prefered language
-        $this->assertEquals('EST', $response->getLanguage());
+        $this->assertSame('EST', $response->getLanguage());
 
         // We should get same message
         $this->assertEquals($this->message, $response->getMessage());
@@ -197,7 +197,7 @@ class IPizzaTest extends TestCase
         $this->assertEquals($this->currency, $response->getCurrency());
         $this->assertEquals($expextedSender, $response->getSender());
         $this->assertEquals($expextedReceiver, $response->getReceiver());
-        $this->assertEquals(100, $response->getTransactionId());
+        $this->assertSame('100', $response->getTransactionId());
         $this->assertEquals($this->datetime, $response->getTransactionDate());
     }
 
@@ -221,7 +221,7 @@ class IPizzaTest extends TestCase
         $response = $this->protocol->handleResponse($responseData);
 
         $this->assertInstanceOf('RKD\Banklink\Response\PaymentResponse', $response);
-        $this->assertEquals(PaymentResponse::STATUS_ERROR, $response->getStatus());
+        $this->assertSame(PaymentResponse::STATUS_ERROR, $response->getStatus());
 
         // This is not valid response, so validation should fail
         $this->assertFalse($response->wasSuccessful());
@@ -315,7 +315,7 @@ class IPizzaTest extends TestCase
         $response = $this->protocol->handleResponse($responseData);
 
         $this->assertInstanceOf('RKD\Banklink\Response\AuthResponse', $response);
-        $this->assertEquals(AuthResponse::STATUS_SUCCESS, $response->getStatus());
+        $this->assertSame(AuthResponse::STATUS_SUCCESS, $response->getStatus());
 
         // This is valid response
         $this->assertTrue($response->wasSuccessful());
@@ -324,37 +324,37 @@ class IPizzaTest extends TestCase
         $this->assertEquals($responseData, $response->getResponseData());
 
         // We should get same prefered language
-        $this->assertEquals('EST', $response->getLanguage());
+        $this->assertSame('EST', $response->getLanguage());
 
         // Test user data
-        $this->assertEquals($responseData['VK_USER_ID'], $response->getUserId());
-        $this->assertEquals($responseData['VK_USER_NAME'], $response->getUserName());
-        $this->assertEquals($responseData['VK_COUNTRY'], $response->getUserCountry());
-        $this->assertEquals($responseData['VK_TOKEN'], $response->getToken());
-        $this->assertEquals($responseData['VK_NONCE'], $response->getNonce());
-        $this->assertEquals($responseData['VK_RID'], $response->getRid());
-        $this->assertEquals($responseData['VK_DATETIME'], $response->getAuthDate());
+        $this->assertSame($responseData['VK_USER_ID'], $response->getUserId());
+        $this->assertSame($responseData['VK_USER_NAME'], $response->getUserName());
+        $this->assertSame($responseData['VK_COUNTRY'], $response->getUserCountry());
+        $this->assertSame($responseData['VK_TOKEN'], $response->getToken());
+        $this->assertSame($responseData['VK_NONCE'], $response->getNonce());
+        $this->assertSame($responseData['VK_RID'], $response->getRid());
+        $this->assertSame($responseData['VK_DATETIME'], $response->getAuthDate());
 
         // Test all auth methods
-        $this->assertEquals('ID card', $response->getAuthMethod());
+        $this->assertSame('ID card', $response->getAuthMethod());
 
         $response->setToken(2);
-        $this->assertEquals('Mobile ID', $response->getAuthMethod());
+        $this->assertSame('Mobile ID', $response->getAuthMethod());
 
         $response->setToken(5);
-        $this->assertEquals('One-off code card', $response->getAuthMethod());
+        $this->assertSame('One-off code card', $response->getAuthMethod());
 
         $response->setToken(6);
-        $this->assertEquals('PIN-calculator', $response->getAuthMethod());
+        $this->assertSame('PIN-calculator', $response->getAuthMethod());
 
         $response->setToken(7);
-        $this->assertEquals('Code card', $response->getAuthMethod());
+        $this->assertSame('Code card', $response->getAuthMethod());
 
         $response->setToken(9);
-        $this->assertEquals('Smart-ID', $response->getAuthMethod());
+        $this->assertSame('Smart-ID', $response->getAuthMethod());
 
         $response->setToken(0);
-        $this->assertEquals('unknown', $response->getAuthMethod());
+        $this->assertSame('unknown', $response->getAuthMethod());
     }
 
     /**
@@ -385,7 +385,7 @@ class IPizzaTest extends TestCase
         $response = $this->protocol->handleResponse($responseData);
 
         $this->assertInstanceOf('RKD\Banklink\Response\AuthResponse', $response);
-        $this->assertEquals(AuthResponse::STATUS_ERROR, $response->getStatus());
+        $this->assertSame(AuthResponse::STATUS_ERROR, $response->getStatus());
 
         // This is not valid response
         $this->assertFalse($response->wasSuccessful());
@@ -507,7 +507,7 @@ class IPizzaTest extends TestCase
     public function testSetAlgorithm()
     {
         $this->protocol->setAlgorithm(OPENSSL_ALGO_SHA256);
-        $this->assertEquals(OPENSSL_ALGO_SHA256, $this->protocol->getAlgorithm());
+        $this->assertSame(OPENSSL_ALGO_SHA256, $this->protocol->getAlgorithm());
     }
 
     /**
@@ -530,7 +530,7 @@ class IPizzaTest extends TestCase
         $requestData = $this->protocol->getAuthRequest();
 
         // Must match with SHA256 encrypted VK_MAC
-        $this->assertEquals(
+        $this->assertSame(
             'BoHSS+z3syMAU0Vi/Ob8lTS8FIMAZ6ZslYnjNXZVEZEn2aXuc/1L2oR/Ef8DvPFJ1ocOjxOHiQ0QJruD5CpiDXI3/hxSJ2qJg0a0HezrTPgc6iVONcsas62+PBlpWFSnZ9u5qg1eETnHgYzjtBZE2FzqWJWC2UuMUxn9uGcGhoxd1wGCrgc2zu4Ub540hhEyoUAJyjN5xA89nKb8H0tY58s96uYM9G8Isj8cDWVICFI4Q5O3Rn56sfhBEyNrSOwMCukf+zsIfoQtt3qto9JZ/IZ6Znl8ze8LCZqwvqnFiRrkXnVwvPI7aiyCIvFccqJiUsl5ahqpXrnFJyt2kyAGDQ==',
             $requestData['VK_MAC']
         );


### PR DESCRIPTION
## Proposed Changes

  - It seems that the package requires `php-7.2` version at least and it should change this PHP version setting on `composer.json` file.
  - Using the `assertSame` to make assert value equals strict.